### PR TITLE
bugfix font-size changes in Firefox and IE

### DIFF
--- a/phylotree.js
+++ b/phylotree.js
@@ -2039,7 +2039,7 @@
         scale_bar.enter().append("g");
         scale_bar
           .attr("class", css_classes["tree-scale-bar"])
-          .style("font-size", "" + scale_bar_font_size)
+          .style("font-size", scale_bar_font_size + "px")
           .attr("transform", function(d) {
             return d3_phylotree_svg_translate([
               offsets[1] + options["left-offset"],
@@ -2488,7 +2488,7 @@
             return node_label(d);
           })
           .style("font-size", function(d) {
-            return shown_font_size;
+            return shown_font_size + "px";
           });
 
         if (phylotree.radial()) {


### PR DESCRIPTION
Hi!
In my current project I implemented a input box for adjusting font size. It worked fine in Chrome, but not in FF and IE, so I tried to debug the problem. I've found solution in this Stackoverflow thread https://stackoverflow.com/questions/34107427/d3-select-style-not-working-on-firefox . 
This PR should fix it in your code as well.

