### PR TITLE
Upgrade jquery to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "phylotree",
   "version": "0.1.6",
   "main": "phylotree.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:veg/phylotree.js.git"
+  },
   "keywords": [
     "phylogenetics",
     "phylogeny",
@@ -16,7 +21,7 @@
     "bootstrap": "3.x",
     "d3": "3.x",
     "font-awesome": "4.x",
-    "jquery": "1.x",
+    "jquery": "3.x",
     "underscore": "1.x",
     "xml2js": "^0.4.19"
   },


### PR DESCRIPTION
This upgrade will fix an audit warning in that jquery v1 had security vulnerabilities. I also added license and repository keys to get rid of some npm warnings. Would it be possible to publish a new version to the npm repository? Thanks!