### PR TITLE
expand node label container to avoid cut-off text

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "docs": "sphinx-build -b html docs documentation",
     "develop": "concurrently \"webpack --watch --mode=development\" \"http-server\"",
     "lint": "eslint --ext .js --ignore-pattern data,docs,images,node_modules ./"
-  }
+  },
+  "files": [ 
+    "phylotree.css",
+    "phylotree.js"
+  ]
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2220,7 +2220,7 @@ d3.layout.phylotree = function(container) {
     var width = 0;
 
     nodes.filter(d3_phylotree_node_visible).forEach(function(node) {
-      var node_width = node_label(node).length * _font_size * 0.8;
+      var node_width = 12 + node_label(node).length * _font_size * 0.8;
       if (node.angle !== null) {
         node_width *= Math.max(
           Math.abs(Math.cos(node.angle)),

--- a/src/main.js
+++ b/src/main.js
@@ -2220,7 +2220,7 @@ d3.layout.phylotree = function(container) {
     var width = 0;
 
     nodes.filter(d3_phylotree_node_visible).forEach(function(node) {
-      var node_width = node_label(node).length * _font_size * 0.6;
+      var node_width = node_label(node).length * _font_size * 0.8;
       if (node.angle !== null) {
         node_width *= Math.max(
           Math.abs(Math.cos(node.angle)),


### PR DESCRIPTION
Closes https://github.com/veg/hyphy/issues/783

Phylotree widgets used in other packages (datamonkey, hyphy-vision, hyphy-gui) occasionally had the node label text cut-off at the end. See "BUS" label at the bottom of the tree below:
<img width="992" alt="screen shot 2018-09-11 at 3 39 08 pm" src="https://user-images.githubusercontent.com/25244432/45383424-2f3f2c00-b5d9-11e8-84b5-c89cb80e3129.png">

This pull request scales the node width-up slightly to avoid that happening:
<img width="979" alt="screen shot 2018-09-11 at 3 38 58 pm" src="https://user-images.githubusercontent.com/25244432/45383465-4847dd00-b5d9-11e8-898c-fe9b38084fd2.png">

_(the additional node labels in the screen shot is a result of some other change since version 0.1.6 and will have to be addressed when we release and integrate the new version of phylotree)_