### PR TITLE
Remove ancestors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Requirements
+
+Node > 9.x.x
+
+## Development workflow
+
+First, run the following commands in order to generate your environment.
+
+```
+git clone http://www.github.com/veg/phylotree.js phylo
+cd phylo
+npm install -g yarn
+yarn global add webpack-cli
+yarn
+yarn develop
+```
+
+At this point, you should be able to navigate to `http://localhost:8080/` from
+your browser.
+
+
+Edit the file `src/main.js` while yarn develop is running in your terminal. Webpack
+will generate `phylotree.js` in the root directory. Any edits to the file
+`phylotree.js` will be overwritten by `webpack`. Note that you'll need to refresh your
+browser after webpack builds to observe changes.

--- a/examples/zoom/hide.html
+++ b/examples/zoom/hide.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang='en'>
+
+<head>
+  <meta charset="utf-8">
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+  <link href="/phylotree.css" rel="stylesheet">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
+
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
+  <script src="//code.jquery.com/jquery.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  <script src="http://d3js.org/d3.v3.min.js"></script>
+  <script src="/phylotree.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js" charset="utf-8"></script>
+  <style>
+#code {
+  display: inline-block;
+  width: 700px;
+  padding-left: 50px;
+}
+  </style>
+</head>
+
+<body>
+  <button id="restore" disabled>Show hidden nodes</button><br/>
+
+  <svg id="tree_display" />
+  <script>
+    var example_tree = "(((EELA:0.150276,CONGERA:0.213019):0.230956,(EELB:0.263487,CONGERB:0.202633):0.246917):0.094785,((CAVEFISH:0.451027,(GOLDFISH:0.340495,ZEBRAFISH:0.390163):0.220565):0.067778,((((((NSAM:0.008113,NARG:0.014065):0.052991,SPUN:0.061003,(SMIC:0.027806,SDIA:0.015298,SXAN:0.046873):0.046977):0.009822,(NAUR:0.081298,(SSPI:0.023876,STIE:0.013652):0.058179):0.091775):0.073346,(MVIO:0.012271,MBER:0.039798):0.178835):0.147992,((BFNKILLIFISH:0.317455,(ONIL:0.029217,XCAU:0.084388):0.201166):0.055908,THORNYHEAD:0.252481):0.061905):0.157214,LAMPFISH:0.717196,((SCABBARDA:0.189684,SCABBARDB:0.362015):0.282263,((VIPERFISH:0.318217,BLACKDRAGON:0.109912):0.123642,LOOSEJAW:0.397100):0.287152):0.140663):0.206729):0.222485,(COELACANTH:0.558103,((CLAWEDFROG:0.441842,SALAMANDER:0.299607):0.135307,((CHAMELEON:0.771665,((PIGEON:0.150909,CHICKEN:0.172733):0.082163,ZEBRAFINCH:0.099172):0.272338):0.014055,((BOVINE:0.167569,DOLPHIN:0.157450):0.104783,ELEPHANT:0.166557):0.367205):0.050892):0.114731):0.295021)"
+
+    var tree = d3.layout.phylotree()
+      .options({
+        brush: false,
+        zoom: true,
+        "left-right-spacing": "fit-to-size",
+        "show-scale": false
+      })
+      .size([100, 900])
+      .svg(d3.select("#tree_display"));
+
+    tree(example_tree)
+      .layout();
+
+    d3.select('#restore')
+      .on("click", function() {
+        d3.selectAll('.branch,.node,.internal-node').style('opacity', 1);
+        $('#restore').attr('disabled', true);
+      }); 
+
+    tree.get_nodes()
+      .filter(node => !d3.layout.phylotree.is_leafnode(node))
+      .forEach(function(internal_node) {
+        d3.layout.phylotree.add_custom_menu(internal_node,
+          "Remove children",
+          function() { 
+            tree.modify_selection(
+              tree.select_all_descendants(internal_node, true, true)
+            )
+            d3.selectAll('.branch,.node,.internal-node').style('opacity', 0);
+            d3.selectAll('.node-selected,.branch-selected').style('opacity', 1);
+            $('#restore').attr('disabled', false);
+            tree.modify_selection(
+              tree.select_all_descendants(internal_node, true, true)
+            )
+          }
+        );
+      });
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Adds an example (`examples/zoom/hide.html`) of hiding all ancestors of a given node; see veg/hyphy#845.