### PR TITLE
Update draw.js

### DIFF
--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -429,16 +429,16 @@ class TreeRender {
       let zoom = d3
         .zoom()
         .scaleExtent([0.1, 10])
-        .on("zoom", () => {
+        .on("zoom", (event) => {
 
           d3.select("." + css_classes["tree-container"]).attr("transform", d => {
-            let toTransform = d3.event.transform;
+            let toTransform = event.transform;
             return toTransform;
           });
 
           // Give some extra room
           d3.select("." + css_classes["tree-scale-bar"]).attr("transform", d => {
-            let toTransform = d3.event.transform;
+            let toTransform = event.transform;
             toTransform.y -= 10; 
             return toTransform;
           });


### PR DESCRIPTION
In recent d3js, you don't get event information using d3.event anymore. For zoom, event is passed as an argument to the event handler