### PR TITLE
Bug in escaping single quotes in Newick export

### DIFF
--- a/src/formats/newick.js
+++ b/src/formats/newick.js
@@ -249,14 +249,14 @@ export function getNewick(annotator, root) {
       element_array.push(")");
     }
 
-    if(n.data.name != 'root') {
-      const node_label = n.data.name.replace("'", "''");
+    if(n.data.name !== 'root') {
+      const node_label = "cow"; // n.data.name.replaceAll("'", "''");
 
       // Escape the entire string if it contains any whitespace.
       if (/\w/.test(node_label)) {
         element_array.push("'" + node_label + "'");
       } else {
-        element_array.push(n.data.name);
+        element_array.push(node_label);
       }
     }
     element_array.push(annotator(n));

--- a/src/formats/newick.js
+++ b/src/formats/newick.js
@@ -252,8 +252,9 @@ export function getNewick(annotator, root) {
     if(n.data.name !== 'root') {
       const node_label = n.data.name.replaceAll("'", "''");
 
-      // Escape the entire string if it contains any whitespace.
-      if (/\w/.test(node_label)) {
+      // Surround the entire string with single quotes if it contains any
+      // non-alphanumeric characters.
+      if (/\W/.test(node_label)) {
         element_array.push("'" + node_label + "'");
       } else {
         element_array.push(node_label);

--- a/src/formats/newick.js
+++ b/src/formats/newick.js
@@ -250,7 +250,7 @@ export function getNewick(annotator, root) {
     }
 
     if(n.data.name !== 'root') {
-      const node_label = "cow"; // n.data.name.replaceAll("'", "''");
+      const node_label = n.data.name.replaceAll("'", "''");
 
       // Escape the entire string if it contains any whitespace.
       if (/\w/.test(node_label)) {

--- a/test/formats-test.js
+++ b/test/formats-test.js
@@ -82,10 +82,10 @@ tape("Handle Newick strings with spaces", function(test) {
    * can read and write Newick strings correctly.
    */
 
-  let nwk = "('Alpha beta', ('Alpha gamma', ('Delta''s epsilon', 'Epsilon zeta ''alphonso''', 'test''')))";
+  let nwk = "('Alpha beta', ('Alpha gamma', ('Delta''s epsilon', 'Epsilon zeta ''alphonso''', 'test''s')))";
   let phylo = new phylotree.phylotree(nwk);
 
-  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon", "Epsilon zeta 'alphonso'", "test'"];
+  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon", "Epsilon zeta 'alphonso'", "test's"];
   test_leaves.forEach(function(leaf) {
     let node = phylo.getNodeByName(leaf);
     test.equal(node.data.name, leaf);
@@ -94,7 +94,7 @@ tape("Handle Newick strings with spaces", function(test) {
   // This would be identical to the original Newick string, but phylotree.js coerces
   // lengths to 1 (see https://github.com/veg/phylotree.js/issues/440). So we expect
   // all lengths to be set to 1 on export.
-  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1,'Epsilon zeta ''alphonso''':1,'test''':1):1):1):1;");
+  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1,'Epsilon zeta ''alphonso''':1,'test''s':1):1):1):1;");
 
   test.end();
 });

--- a/test/formats-test.js
+++ b/test/formats-test.js
@@ -94,7 +94,7 @@ tape("Handle Newick strings with spaces", function(test) {
   // This would be identical to the original Newick string, but phylotree.js coerces
   // lengths to 1 (see https://github.com/veg/phylotree.js/issues/440). So we expect
   // all lengths to be set to 1 on export.
-  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1, 'Epsilon zeta ''alphonso''':1):1):1):1;");
+  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1,'Epsilon zeta ''alphonso''':1):1):1):1;");
 
   test.end();
 });

--- a/test/formats-test.js
+++ b/test/formats-test.js
@@ -82,10 +82,10 @@ tape("Handle Newick strings with spaces", function(test) {
    * can read and write Newick strings correctly.
    */
 
-  let nwk = "('Alpha beta', ('Alpha gamma', ('Delta''s epsilon', 'Epsilon zeta ''alphonso''')))";
+  let nwk = "('Alpha beta', ('Alpha gamma', ('Delta''s epsilon', 'Epsilon zeta ''alphonso''', 'test''')))";
   let phylo = new phylotree.phylotree(nwk);
 
-  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon", "Epsilon zeta 'alphonso'"];
+  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon", "Epsilon zeta 'alphonso'", "test'"];
   test_leaves.forEach(function(leaf) {
     let node = phylo.getNodeByName(leaf);
     test.equal(node.data.name, leaf);
@@ -94,7 +94,7 @@ tape("Handle Newick strings with spaces", function(test) {
   // This would be identical to the original Newick string, but phylotree.js coerces
   // lengths to 1 (see https://github.com/veg/phylotree.js/issues/440). So we expect
   // all lengths to be set to 1 on export.
-  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1,'Epsilon zeta ''alphonso''':1):1):1):1;");
+  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1,'Epsilon zeta ''alphonso''':1,'test''':1):1):1):1;");
 
   test.end();
 });

--- a/test/formats-test.js
+++ b/test/formats-test.js
@@ -82,10 +82,10 @@ tape("Handle Newick strings with spaces", function(test) {
    * can read and write Newick strings correctly.
    */
 
-  let nwk = "('Alpha beta', ('Alpha gamma', 'Delta''s epsilon'))";
+  let nwk = "('Alpha beta', ('Alpha gamma', ('Delta''s epsilon', 'Epsilon zeta ''alphonso''')))";
   let phylo = new phylotree.phylotree(nwk);
 
-  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon"];
+  let test_leaves = ['Alpha beta', 'Alpha gamma', "Delta's epsilon", "Epsilon zeta 'alphonso'"];
   test_leaves.forEach(function(leaf) {
     let node = phylo.getNodeByName(leaf);
     test.equal(node.data.name, leaf);
@@ -94,7 +94,7 @@ tape("Handle Newick strings with spaces", function(test) {
   // This would be identical to the original Newick string, but phylotree.js coerces
   // lengths to 1 (see https://github.com/veg/phylotree.js/issues/440). So we expect
   // all lengths to be set to 1 on export.
-  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,'Delta''s epsilon':1):1):1;");
+  test.equal(phylo.getNewick(), "('Alpha beta':1,('Alpha gamma':1,('Delta''s epsilon':1, 'Epsilon zeta ''alphonso''':1):1):1):1;");
 
   test.end();
 });


### PR DESCRIPTION
I made a dumb mistake in my previous PR (#441) where I used `replace()` instead of `replaceAll()`, so that only the first single quote was being escaped.

This PR fixes that, as well as making a few other minor fixes:
- Added a test to catch this bug.
- Replaced one use of `!=` with `!==`.
- Cleaned up the code, possibly fixing some other bugs as well.

Closes https://github.com/veg/phylotree.js/issues/450.