### PR TITLE
selectionCallback fix

### DIFF
--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -31,7 +31,7 @@ class TreeRender {
 
     this._nodeLabel = this.defNodeLabel;
     this.svg = null;
-    this.selectionCallback = null;
+    this._selectionCallback = null;
     this.scales = [1, 1];
     this.size = [1, 1];
     this.fixed_width = [14, 30];

--- a/src/render/menus.js
+++ b/src/render/menus.js
@@ -388,8 +388,8 @@ export function modifySelection(
     }
   }
 
-  if (this.selectionCallback && attr != "tag") {
-    this.selectionCallback(this.getSelection());
+  if (this._selectionCallback && attr != "tag") {
+    this._selectionCallback(this.getSelection());
   }
 
   this.refresh();
@@ -444,10 +444,10 @@ export function selectAllDescendants(node, terminal, internal) {
  * an array of nodes that make up the current selection.
  *
  * @param {Function} callback (Optional) The selection callback function.
- * @returns The current ``selectionCallback`` if getting, or the current ``this`` if setting.
+ * @returns The current ``_selectionCallback`` if getting, or the current ``this`` if setting.
  */
 export function selectionCallback(callback) {
-  if (!callback) return this.selectionCallback;
-  this.selectionCallback = callback;
+  if (!callback) return this._selectionCallback;
+  this._selectionCallback = callback;
   return this;
 }

--- a/src/render/menus.js
+++ b/src/render/menus.js
@@ -403,7 +403,7 @@ export function modifySelection(
  * @returns {Array} An array of nodes that match the current selection.
  */
 export function getSelection() {
-  return this.nodes.filter(d => {
+  return selectAllDescendants(this.phylotree.getRootNode(), true, true).filter(d => {
     return d[this.selection_attribute_name];
   });
 }

--- a/src/render/options.js
+++ b/src/render/options.js
@@ -132,10 +132,10 @@ export var predefined_selecters = {
  * an array of nodes that make up the current selection.
  *
  * @param {Function} callback (Optional) The selection callback function.
- * @returns The current ``selectionCallback`` if getting, or the current ``this`` if setting.
+ * @returns The current ``_selectionCallback`` if getting, or the current ``this`` if setting.
  */
 export function selectionCallback(callback) {
-  if (!callback) return this.selectionCallback;
-  this.selectionCallback = callback;
+  if (!callback) return this._selectionCallback;
+  this._selectionCallback = callback;
   return this;
 }


### PR DESCRIPTION
`selectionCallback()` was not usable because it was overridden by the identically named `selectionCallback` member. Furthermore, `getSelection()` used a non-existing `nodes` field, which has been replaced.