### PR TITLE
Fix zoom transform reset after branch selection

### DIFF
--- a/src/render/events.js
+++ b/src/render/events.js
@@ -53,17 +53,25 @@ export function resizeSvg(tree, svg, tr) {
       sizes[0] + 2 * pad_radius + vertical_offset
     ];
 
+    // Update base transform for radial layout
+    this.baseTransform = {
+      x: pad_radius,
+      y: pad_radius + vertical_offset
+    };
+
     if (svg) {
+      // Compose with zoom transform if present
+      let transform;
+      if (this.currentZoomTransform && this.options["zoom"]) {
+        const zt = this.currentZoomTransform;
+        transform = `translate(${zt.x + this.baseTransform.x * zt.k}, ${zt.y + this.baseTransform.y * zt.k}) scale(${zt.k})`;
+      } else {
+        transform = "translate(" + pad_radius + "," + (pad_radius + vertical_offset) + ")";
+      }
+
       svg
         .selectAll("." + css_classes["tree-container"])
-        .attr(
-          "transform",
-          "translate (" +
-            pad_radius +
-            "," +
-            (pad_radius + vertical_offset) +
-            ")"
-        );
+        .attr("transform", transform);
     }
   } else {
 


### PR DESCRIPTION
## Summary

Fixes #467 and #474 - Zoom state was being lost when `update()` was called (e.g., after selecting a branch, collapsing nodes, or other interactions that trigger a re-render).

**Root cause:** The tree-container's transform attribute was unconditionally overwritten in `update()` with just the base position translate, discarding any zoom/pan transform that had been applied by the user.

**Solution:**
- Store `currentZoomTransform` and `baseTransform` as instance variables
- Compose zoom transform with base transform when setting the tree-container transform
- Reuse the zoom behavior across updates instead of recreating it each time
- Restore the zoom transform after `update()` completes to sync d3-zoom's internal state
- Apply the same fix to `resizeSvg()` for radial layouts

## Test plan

- [ ] Enable zoom on a tree: `tree.render({ zoom: true, ... })`
- [ ] Pan and zoom the tree
- [ ] Click on a branch to select it
- [ ] Verify the zoom/pan position is preserved (previously it would reset)
- [ ] Test with radial layout as well
- [ ] Test with multiple trees on the same page (#474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)