### PR TITLE
Fix zoom not working for multiple trees on same page

### DIFF
--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -510,10 +510,11 @@ class TreeRender {
             const zt = event.transform;
             const composedTransform = `translate(${zt.x + this.baseTransform.x * zt.k}, ${zt.y + this.baseTransform.y * zt.k}) scale(${zt.k})`;
 
-            d3.select("." + css_classes["tree-container"]).attr("transform", composedTransform);
+            // Use this.svg.select() to target only this tree instance (not global d3.select)
+            this.svg.select("." + css_classes["tree-container"]).attr("transform", composedTransform);
 
             // Apply same transform to scale bar
-            d3.select("." + css_classes["tree-scale-bar"]).attr("transform", d => {
+            this.svg.select("." + css_classes["tree-scale-bar"]).attr("transform", d => {
               return `translate(${zt.x + this.baseTransform.x * zt.k}, ${zt.y + (this.baseTransform.y - 10) * zt.k}) scale(${zt.k})`;
             });
           });


### PR DESCRIPTION
## Summary

Fixes #474 - When multiple trees are rendered on the same page, zooming only affected the first tree.

**Root cause:** The zoom event handler used global `d3.select()` to find elements:
```javascript
d3.select("." + css_classes["tree-container"])
```

This always selects the **first** matching element in the DOM, regardless of which tree instance initiated the zoom.

**Fix:** Use `this.svg.select()` to scope the selection to this specific tree instance's SVG element:
```javascript
this.svg.select("." + css_classes["tree-container"])
```

## Test plan

- [ ] Render multiple trees with `zoom: true` on the same page
- [ ] Verify each tree zooms independently when scrolling on it
- [ ] Verify zooming one tree does NOT affect other trees

Test page available at: `dist/test-multi-tree.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)