### PR TITLE
Fix custom edge styling not applying to selected branches (#473)

### DIFF
--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -317,6 +317,10 @@ class TreeRender {
 
     this.placenodes();
 
+    // Sync edge labels BEFORE drawing edges so that edge.selected reflects node.selected
+    // This is critical for custom edge stylers that rely on selection state
+    this.syncEdgeLabels();
+
     transitions = this.transitions(transitions);
 
     let node_id = 0;
@@ -494,7 +498,8 @@ class TreeRender {
       brush.call(brush_object);
     }
 
-    this.syncEdgeLabels();
+    // Note: syncEdgeLabels() is called at the start of update() before edges are drawn
+    // to ensure selection state is synced before reclassEdge and edge_styler run
 
     if (this.options["zoom"]) {
       // Create zoom behavior if not already created


### PR DESCRIPTION
## Summary
- Fixed issue where custom edge-styler functions didn't apply styles to selected branches
- Root cause: `syncEdgeLabels()` was called AFTER edges were drawn, so `edge.selected` was undefined when `reclassEdge()` and `edge_styler` ran
- Solution: Move `syncEdgeLabels()` to run before drawing edges

## Test plan
- [x] Run existing tests (all 61 pass)
- [x] Verify custom edge-styler can now check `edge.selected` or `edge.target.selected`
- [x] Build completes successfully

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)