### PR TITLE
Fix RTL mode labels overlapping with branches (#212)

### DIFF
--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -1071,10 +1071,9 @@ class TreeRender {
         d.y *= this.scales[1]*.8;
 
         if (this.options["layout"] == "right-to-left") {
-          // For RTL with align-tips, add label_width offset to shift tree right,
-          // creating space on the left for aligned labels
-          const rtlLabelOffset = this.options["align-tips"] ? this.label_width : 0;
-          d.y = this._extents[1][1] * this.scales[1] - d.y + rtlLabelOffset;
+          // For RTL, always add label_width offset to shift tree right,
+          // creating space on the left for labels (prevents labels overlapping branches)
+          d.y = this._extents[1][1] * this.scales[1] - d.y + this.label_width;
         }
 
 


### PR DESCRIPTION
## Summary
- Fixed issue where node labels in RTL (right-to-left) layout mode overlapped with tree branches
- Root cause: Labels were positioned at tip positions without leaving space on the left side
- Solution: Always add `label_width` offset in RTL mode to shift the tree right and create space for labels

## Test plan
- [x] Run existing tests (all 61 pass)
- [x] Build completes successfully
- [ ] Verify RTL mode has proper label spacing in browser

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)