### PR TITLE
Fix YAML syntax error in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,18 +73,11 @@ jobs:
           const fs = require('fs');
           const apiDocs = fs.readFileSync('API.md', 'utf8');
           const preview = apiDocs.substring(0, 2000) + (apiDocs.length > 2000 ? '\n\n... (truncated)' : '');
-          
+          const codeBlock = '```';
+
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `## 📖 API Documentation Preview
-            
-The API documentation has been updated in this PR. Here's a preview:
-
-\`\`\`markdown
-${preview}
-\`\`\`
-
-Full documentation will be available at: https://${context.repo.owner}.github.io/${context.repo.repo}/API.md when merged.`
+            body: `## API Documentation Preview\n\nThe API documentation has been updated in this PR. Here is a preview:\n\n${codeBlock}markdown\n${preview}\n${codeBlock}\n\nFull documentation will be available at: https://${context.repo.owner}.github.io/${context.repo.repo}/API.md when merged.`
           });


### PR DESCRIPTION
## Summary
Fixed YAML syntax error on line 85 of `.github/workflows/docs.yml`.

The backticks in the JavaScript template literal were causing YAML parsing issues. Fixed by:
- Storing backticks in a variable: `const codeBlock = '\`\`\`';`
- Using single-line body string with `\n` for newlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)